### PR TITLE
Use an application factory

### DIFF
--- a/_lib/deployment.py
+++ b/_lib/deployment.py
@@ -16,7 +16,7 @@ _UNIX_SOCKET_NAME = "/tmp/__{0}_uwsgi.sock".format(APP_NAME)
 def run_uwsgi(catch_exceptions):
     uwsgi_bin = from_env_bin("uwsgi")
     cmd = [uwsgi_bin, "-b", "16384", "--chmod-socket=666",
-           "--home", from_env(), "--pythonpath", from_project_root(), "--module=flask_app.app", "--callable=app",
+           "--home", from_env(), "--pythonpath", from_project_root(), "--module=flask_app.wsgi", "--callable=app",
            "-s", _UNIX_SOCKET_NAME, "-p", str(cpu_count())]
     if catch_exceptions:
         cmd.append("--catch-exceptions")

--- a/flask_app/errors.py
+++ b/flask_app/errors.py
@@ -1,11 +1,11 @@
-from .app import app
-
 from flask import render_template, make_response
 
+errors = {}
+
 def _define_custom_error_page(code):
-    @app.errorhandler(code)
     def _handler(err):
         return make_response(render_template("errors/{}.html".format(code)), code)
+    errors[code] = _handler
 
 _define_custom_error_page(500)
 _define_custom_error_page(404)

--- a/flask_app/views.py
+++ b/flask_app/views.py
@@ -1,9 +1,9 @@
-from flask import render_template
+from flask import render_template, Blueprint
 import sys
 
-from .app import app
 
+views = Blueprint("views", __name__, template_folder="templates")
 
-@app.route("/")
+@views.route("/")
 def index():
     return render_template("index.html", version=sys.version)

--- a/flask_app/wsgi.py
+++ b/flask_app/wsgi.py
@@ -1,0 +1,3 @@
+from .app import create_app
+
+app = create_app()

--- a/manage.py
+++ b/manage.py
@@ -59,7 +59,8 @@ def bootstrap(develop, app):
 @cli.command()
 @requires_env("app", "develop")
 def testserver():
-    from flask_app.app import app
+    from flask_app.app import create_app
+    app = create_app()
     app.config["DEBUG"] = True
     app.config["TESTING"] = True
     app.config["SECRET_KEY"] = "dummy secret key"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def deployment_webapp_url(request):
 
 @pytest.fixture
 def webapp(request):
-    returned = Webapp(app.app)
+    returned = Webapp(app.create_app())
     returned.app.config["SECRET_KEY"] = "testing_key"
     returned.app.config["TESTING"] = True
     returned.activate()


### PR DESCRIPTION
I checked the test server, vagant deployment, Docker and unittest and all seems to work.
Errors cannot be registered using a blueprint so the error module is registered in a unique way. Other modules should be registered using a blueprint just like views does
