### PR TITLE
use py.test args in manage.py pytest

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -120,6 +120,18 @@ def _run_unittest():
 
 
 @cli.command()
+@click.argument('pytest_args', nargs=-1)
+def pytest(pytest_args):
+    _run_pytest(pytest_args)
+
+
+@requires_env("app", "develop")
+def _run_pytest(pytest_args=()):
+    subprocess.check_call(
+        [from_env_bin("py.test")]+list(pytest_args), cwd=from_project_root())
+
+
+@cli.command()
 def fulltest():
     _run_fulltest()
 


### PR DESCRIPTION
I'm using this in DHCPawn to not have to enter the virtualenv for full pytest usage. The args could also be given to fulltest or unittest, but this seemed like a non-intrusive way to add this.

Example

python manage.py pytest -- -v --tb=no
python manage.py pytest -- -k test_index_view
